### PR TITLE
Put code back so it shows up in samples in storybook docs

### DIFF
--- a/stories/Button.stories.tsx
+++ b/stories/Button.stories.tsx
@@ -8,32 +8,6 @@ import { color } from '../src/styles';
 
 const onClickAction = action('Button clicked');
 
-const defaultButton = <Button onClick={onClickAction}>Default</Button>;
-const fullWidthButton = (
-  <Button fullWidth onClick={onClickAction}>
-    Full Width
-  </Button>
-);
-const allCapsButton = (
-  <Button allCaps onClick={onClickAction}>
-    all caps
-  </Button>
-);
-
-const lightButton = (
-  <div
-    style={{
-      backgroundColor: color.grey.lightPageBackground,
-      padding: '1rem',
-      margin: '1rem 0',
-    }}
-  >
-    <Button lightBorder onClick={onClickAction}>
-      Light Border
-    </Button>
-  </div>
-);
-
 storiesOf('Button', module)
   .addParameters({
     component: Button,
@@ -43,17 +17,60 @@ storiesOf('Button', module)
     'Summary',
     (): React.ReactElement => (
       <>
-        {defaultButton}
-        {allCapsButton}
-        {lightButton}
-        {fullWidthButton}
+        <Button onClick={onClickAction}>Default</Button>
+        <Button allCaps onClick={onClickAction}>
+          all caps
+        </Button>
+        <div
+          style={{
+            backgroundColor: color.black,
+            padding: '1rem',
+            margin: '1rem 0',
+          }}
+        >
+          <Button lightBorder onClick={onClickAction}>
+            Light Border
+          </Button>
+        </div>
+        <Button fullWidth onClick={onClickAction}>
+          Full Width
+        </Button>
       </>
     )
   )
-  .addWithJSX('default', (): React.ReactElement => defaultButton)
-  .addWithJSX('full width', (): React.ReactElement => fullWidthButton)
-  .addWithJSX('all caps', (): React.ReactElement => allCapsButton)
+  .addWithJSX(
+    'default',
+    (): React.ReactElement => <Button onClick={onClickAction}>Default</Button>
+  )
+  .addWithJSX(
+    'full width',
+    (): React.ReactElement => (
+      <Button fullWidth onClick={onClickAction}>
+        Full Width
+      </Button>
+    )
+  )
+  .addWithJSX(
+    'all caps',
+    (): React.ReactElement => (
+      <Button allCaps onClick={onClickAction}>
+        all caps
+      </Button>
+    )
+  )
   .addWithJSX(
     'light border on a dark background',
-    (): React.ReactElement => lightButton
+    (): React.ReactElement => (
+      <div
+        style={{
+          backgroundColor: color.black,
+          padding: '1rem',
+          margin: '1rem 0',
+        }}
+      >
+        <Button lightBorder onClick={onClickAction}>
+          Light Border
+        </Button>
+      </div>
+    )
   );


### PR DESCRIPTION
# Description
mitigating a display bug with code samples in the generated docs - they need to be directly in the story to be shared in docs for now.