### PR TITLE
Disable percy tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,15 +61,14 @@ workflows:
   build_and_test:
     jobs:
       - build
-      - percy-tests:
-          requires:
-            - build
-
-          filters:
-            branches:
-              # ignore PRs from dependabot so we don't boil off percy time needlessly
-              ignore: /^dependabot/
-      - percy/finalize_all:
-          requires:
-            - build
-            - percy-tests
+      # - percy-tests:
+      #     requires:
+      #       - build
+      #     filters:
+      #       branches:
+      #         # ignore PRs from dependabot so we don't boil off percy time needlessly
+      #         ignore: /^dependabot/
+      # - percy/finalize_all:
+      #     requires:
+      #       - build
+      #       - percy-tests


### PR DESCRIPTION
# Description
Until we work out a paid license for some kind of snapshot testing, the service is going to waste each month.  Commenting out the lines that push builds from CI to Percy :🤷‍♂️